### PR TITLE
Fix Home Assistant 2026 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
 # xiaomi_vacuum
+
 Home Assistant custom component for Vacuum 1C SKV4073CN (mijia.vacuum.v2).
 
 Based on https://github.com/DavidConnack/xiaomi_vacuum
 
 Using https://github.com/rytilahti/python-miio for the protocol.
 
-Installation:
-- Add the "xiaomi_vacuum" folder to the /config/custom_components folder
-- Add the xiaomi_vacuum_card.png to /config/www/Vacuum folder
-- Add sensor_xiaomi_vacuum.yaml  to /config
-- Add to configuration.yaml :
-```
+## Installation
+
+- Add the `custom_components/xiaomi_vacuum` folder to `/config/custom_components/`
+- Add `xiaomi_vacuum_card.png` to `/config/www/Vacuum/`
+- Add `sensor_xiaomi_vacuum.yaml` to `/config`
+- Add to `configuration.yaml`:
+
+```yaml
 vacuum:
   - platform: xiaomi_vacuum
     host: <ip>
     token: "<token>"
     name: <name>
 
-sensor: !include sensor_xiaomi_vacuum.yaml
+template: !include sensor_xiaomi_vacuum.yaml
 ```
-(To retrieve the token, follow the default integration <a href="https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token">instructions</a>)
-- Reboot
-- Add content of lovelace-card.yaml to custom card
+
+To retrieve the token, follow the default integration [instructions](https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token).
+
+- Restart Home Assistant
+- Add content of `lovelace-card.yaml` to a custom card
+
+## Home Assistant 2026.x
+
+The component uses `VacuumEntityFeature` and `VacuumActivity` from Home Assistant 2025.10+.
+Battery level is exposed as a state attribute for template sensors instead of the deprecated vacuum `battery_level` property.

--- a/custom_components/xiaomi_vacuum/manifest.json
+++ b/custom_components/xiaomi_vacuum/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "xiaomi_vacuum",
   "name": "Xiaomi Vacuum",
-  "documentation": "",
-  "requirements": ["python-miio==0.5.12"],
+  "documentation": "https://github.com/duckhawk/xiaomi_vacuum",
+  "requirements": ["python-miio>=0.5.12"],
   "codeowners": ["@duckhawk"],
-  "version": "0.1"
+  "version": "0.2.0"
 }

--- a/custom_components/xiaomi_vacuum/vacuum.py
+++ b/custom_components/xiaomi_vacuum/vacuum.py
@@ -1,30 +1,20 @@
-"""Xiaomi Vacuum"""
+"""Xiaomi Vacuum."""
+from __future__ import annotations
+
+from datetime import timedelta
 from functools import partial
 import logging
-import voluptuous as vol
 
-from miio import DeviceException
-from miio import G1Vacuum
+import voluptuous as vol
+from miio import DeviceException, G1Vacuum
+from miio.integrations.vacuum.mijia.g1vacuum import G1FanSpeed, G1State, G1WaterLevel
 
 from homeassistant.components.vacuum import (
     PLATFORM_SCHEMA,
-    SUPPORT_STATE,
-    SUPPORT_BATTERY,
-    SUPPORT_LOCATE,
-    SUPPORT_PAUSE,
-    SUPPORT_RETURN_HOME,
-    SUPPORT_START,
-    SUPPORT_STOP,
-    SUPPORT_FAN_SPEED,
-    STATE_CLEANING,
-    STATE_IDLE,
-    STATE_PAUSED,
-    STATE_RETURNING,
-    STATE_DOCKED,
-    STATE_ERROR,
     StateVacuumEntity,
+    VacuumActivity,
+    VacuumEntityFeature,
 )
-
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.helpers import config_validation as cv, entity_platform
 
@@ -53,7 +43,8 @@ ATTR_SIDE_BRUSH_LEFT_TIME = "side_brush_time_left"
 ATTR_SIDE_BRUSH_LIFE_LEVEL = "side_brush_life_level"
 ATTR_FILTER_LIFE_LEVEL = "filter_life_level"
 ATTR_FILTER_LEFT_TIME = "filter_left_time"
-ATTR_CLEANING_TOTAL_TIME = "total_cleaning_count"
+ATTR_SENSOR_DIRTY_LEFT = "sensor_dirty_left"
+ATTR_BATTERY_LEVEL = "battery_level"
 ATTR_ZONE_ARRAY = "zone"
 ATTR_ZONE_REPEATER = "repeats"
 ATTR_WATER_LEVEL = "water_level"
@@ -62,69 +53,42 @@ SERVICE_CLEAN_ZONE = "vacuum_clean_zone"
 SERVICE_WATER_LEVEL = "set_water_level"
 
 SUPPORT_XIAOMI = (
-    SUPPORT_STATE
-    | SUPPORT_BATTERY
-    | SUPPORT_LOCATE
-    | SUPPORT_RETURN_HOME
-    | SUPPORT_START
-    | SUPPORT_STOP
-    | SUPPORT_PAUSE
-    | SUPPORT_FAN_SPEED
+    VacuumEntityFeature.STATE
+    | VacuumEntityFeature.LOCATE
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.START
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.PAUSE
+    | VacuumEntityFeature.FAN_SPEED
 )
 
-STATE_CODE_TO_STATE = {
-    1: STATE_CLEANING,
-    2: STATE_IDLE,
-    3: STATE_PAUSED,
-    4: STATE_ERROR,
-    5: STATE_RETURNING,
-    6: STATE_DOCKED,
+G1_STATE_TO_ACTIVITY = {
+    G1State.Idle: VacuumActivity.IDLE,
+    G1State.Sweeping: VacuumActivity.CLEANING,
+    G1State.Paused: VacuumActivity.PAUSED,
+    G1State.Error: VacuumActivity.ERROR,
+    G1State.Charging: VacuumActivity.DOCKED,
+    G1State.GoCharging: VacuumActivity.RETURNING,
 }
 
 SPEED_CODE_TO_NAME = {
-    0: "Mute",
-    1: "Standard",
-    2: "Medium",
-    3: "High",
+    G1FanSpeed.Mute: "Mute",
+    G1FanSpeed.Standard: "Standard",
+    G1FanSpeed.Medium: "Medium",
+    G1FanSpeed.High: "High",
 }
 
 WATER_CODE_TO_NAME = {
-    1: "Low",
-    2: "Med",
-    3: "High",
+    G1WaterLevel.Low: "Low",
+    G1WaterLevel.Medium: "Med",
+    G1WaterLevel.High: "High",
 }
 
-ERROR_CODE_TO_ERROR = {
-    0: "NoError",
-    1: "Drop",
-    2: "Cliff",
-    3: "Bumper",
-    4: "Gesture",
-    5: "Bumper_repeat",
-    6: "Drop_repeat",
-    7: "Optical_flow",
-    8: "No_box",
-    9: "No_tankbox",
-    10: "Waterbox_empty",
-    11: "Box_full",
-    12: "Brush",
-    13: "Side_brush",
-    14: "Fan",
-    15: "Left_wheel_motor",
-    16: "Right_wheel_motor",
-    17: "Turn_suffocate",
-    18: "Forward_suffocate",
-    19: "Charger_get",
-    20: "Battery_low",
-    21: "Charge_fault",
-    22: "Battery_percentage",
-    23: "Heart",
-    24: "Camera_occlusion",
-    25: "Camera_fault",
-    26: "Event_battery",
-    27: "Forward_looking",
-    28: "Gyroscope",
-}
+
+def _timedelta_minutes(value: timedelta | None) -> int | None:
+    if value is None:
+        return None
+    return int(value.total_seconds() / 60)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -132,18 +96,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
-    host = config.get(CONF_HOST)
-    token = config.get(CONF_TOKEN)
-    name = config.get(CONF_NAME)
+    host = config[CONF_HOST]
+    token = config[CONF_TOKEN]
+    name = config[CONF_NAME]
 
-    # Create handler
-    _LOGGER.info("Initializing with host %s (token %s...)", host, token)
+    _LOGGER.info("Initializing with host %s (token %s...)", host, token[:8])
     vacuum = G1Vacuum(host, token)
 
-    mirobo = MiroboVacuum(name, vacuum)
-    hass.data[DATA_KEY][host] = mirobo
+    entity = MiroboVacuum(name, vacuum)
+    hass.data[DATA_KEY][host] = entity
 
-    async_add_entities([mirobo], update_before_add=True)
+    async_add_entities([entity], update_before_add=True)
 
     platform = entity_platform.current_platform.get()
 
@@ -160,181 +123,121 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     platform.async_register_entity_service(
         SERVICE_WATER_LEVEL,
-        {
-            vol.Required(ATTR_WATER_LEVEL): cv.string,
-        },
+        {vol.Required(ATTR_WATER_LEVEL): cv.string},
         MiroboVacuum.async_set_water_level.__name__,
     )
+
 
 class MiroboVacuum(StateVacuumEntity):
     """Representation of a Xiaomi Vacuum cleaner robot."""
 
-    def __init__(self, name, vacuum):
-        """Initialize the Xiaomi vacuum cleaner robot handler."""
-        self._name = name
+    def __init__(self, name: str, vacuum: G1Vacuum) -> None:
+        self._attr_name = name
         self._vacuum = vacuum
-
-        self._fan_speeds = None
-        self._fan_speeds_reverse = None
-
-        self.vacuum_state = None
-        self.vacuum_error = None
-        self.battery_percentage = None
-
-        self._current_fan_speed = None
-
-        self._main_brush_time_left = None
-        self._main_brush_life_level = None
-
-        self._side_brush_time_left = None
-        self._side_brush_life_level = None
-
-        self._filter_life_level = None
-        self._filter_left_time = None
-
-        self._cleaning_area = None
-        self._cleaning_time = None
-
-        self._water_level = None
-        self._current_water_level = None
-        self._water_level_reverse = None
-
+        self._fan_speeds_reverse: dict[str, int] | None = None
+        self._water_level_reverse: dict[str, int] | None = None
+        self._attr_activity: VacuumActivity | None = None
+        self._error: str | None = None
+        self._battery_percentage: int | None = None
+        self._current_fan_speed: int | None = None
+        self._main_brush_time_left: int | None = None
+        self._main_brush_life_level: int | None = None
+        self._side_brush_time_left: int | None = None
+        self._side_brush_life_level: int | None = None
+        self._filter_life_level: int | None = None
+        self._filter_left_time: int | None = None
+        self._cleaning_area: int | None = None
+        self._cleaning_time: int | None = None
+        self._current_water_level: int | None = None
 
     @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
+    def fan_speed(self) -> str | None:
+        if self._current_fan_speed is None or self._fan_speeds_reverse is None:
+            return None
+        for speed, code in self._fan_speeds_reverse.items():
+            if code == self._current_fan_speed:
+                return speed
+        return str(self._current_fan_speed)
 
     @property
-    def state(self):
-        """Return the status of the vacuum cleaner."""
-        if self.vacuum_state is not None:
-            return self.vacuum_state
-
-    @property
-    def error(self):
-        """Return the error of the vacuum cleaner."""
-        if self.vacuum_error is not None:
-            try:
-                return ERROR_CODE_TO_ERROR.get(self.vacuum_error, "Unknown")
-            except KeyError:
-                _LOGGER.error(
-                    "ERROR_CODE not supported: %s",
-                    self.vacuum_error,
-                )
-                return None
-
-    @property
-    def battery_level(self):
-        """Return the battery level of the vacuum cleaner."""
-        if self.vacuum_state is not None:
-            return self.battery_percentage
-
-    @property
-    def fan_speed(self):
-        """Return the fan speed of the vacuum cleaner."""
-        if self.vacuum_state is not None:
-            speed = self._current_fan_speed
-            if speed in self._fan_speeds_reverse:
-                return SPEED_CODE_TO_NAME.get(self._current_fan_speed, "Unknown")
-
-            _LOGGER.debug("Unable to find reverse for %s", speed)
-
-            return speed
-
-    @property
-    def fan_speed_list(self):
-        """Get the list of available fan speed steps of the vacuum cleaner."""
+    def fan_speed_list(self) -> list[str]:
+        if self._fan_speeds_reverse is None:
+            return []
         return list(self._fan_speeds_reverse)
 
     @property
-    def water_level(self):
-        """Return the fan speed of the vacuum cleaner."""
-        if self.vacuum_state is not None:
-            water = self._current_water_level
-            if water in self._water_level_reverse:
-                return WATER_CODE_TO_NAME.get(self._current_water_level, "Unknown")
-
-            _LOGGER.debug("Unable to find reverse for %s", speed)
-
-            return water
-
-    @property
-    def water_level_list(self):
-        """Get the list of available water level list of the vacuum cleaner."""
-        return list(self._water_level_reverse)
-
-    @property
-    def extra_state_attributes(self):
-        """Return the specific state attributes of this vacuum cleaner."""
-        if self.vacuum_state is not None:
-            return {
-                ATTR_STATUS: self.vacuum_state,
-                ATTR_ERROR:  self.vacuum_error,
-				ATTR_FAN_SPEED: self._current_fan_speed,
-                ATTR_MAIN_BRUSH_LEFT_TIME: self._main_brush_time_left,
-                ATTR_MAIN_BRUSH_LIFE_LEVEL: self._main_brush_life_level,
-                ATTR_SIDE_BRUSH_LEFT_TIME: self._side_brush_time_left,
-                ATTR_SIDE_BRUSH_LIFE_LEVEL: self._side_brush_life_level,
-                ATTR_FILTER_LIFE_LEVEL: self._filter_life_level,
-                ATTR_FILTER_LEFT_TIME: self._filter_left_time,
-                ATTR_CLEANING_AREA: self._cleaning_area,
-                ATTR_CLEANING_TIME: self._cleaning_time,
-				ATTR_WATER_LEVEL: self._current_water_level,
-				"water_level_list": ["Low", "Med", "High"],
-            }
-
+    def extra_state_attributes(self) -> dict[str, object] | None:
+        if self._attr_activity is None:
+            return None
+        return {
+            ATTR_STATUS: self._attr_activity,
+            ATTR_ERROR: self._error,
+            ATTR_FAN_SPEED: self.fan_speed,
+            ATTR_BATTERY_LEVEL: self._battery_percentage,
+            ATTR_MAIN_BRUSH_LEFT_TIME: self._main_brush_time_left,
+            ATTR_MAIN_BRUSH_LIFE_LEVEL: self._main_brush_life_level,
+            ATTR_SIDE_BRUSH_LEFT_TIME: self._side_brush_time_left,
+            ATTR_SIDE_BRUSH_LIFE_LEVEL: self._side_brush_life_level,
+            ATTR_FILTER_LIFE_LEVEL: self._filter_life_level,
+            ATTR_FILTER_LEFT_TIME: self._filter_left_time,
+            ATTR_SENSOR_DIRTY_LEFT: self._filter_life_level,
+            ATTR_CLEANING_AREA: self._cleaning_area,
+            ATTR_CLEANING_TIME: self._cleaning_time,
+            ATTR_WATER_LEVEL: self._water_level_name,
+            "water_level_list": list(WATER_CODE_TO_NAME.values()),
+        }
 
     @property
-    def supported_features(self):
-        """Flag vacuum cleaner robot features that are supported."""
+    def supported_features(self) -> VacuumEntityFeature:
         return SUPPORT_XIAOMI
 
-    async def _try_command(self, mask_error, func, *args, **kwargs):
-        """Call a vacuum command handling error messages."""
+    @property
+    def _water_level_name(self) -> str | None:
+        if self._current_water_level is None or self._water_level_reverse is None:
+            return None
+        for name, code in self._water_level_reverse.items():
+            if code == self._current_water_level:
+                return name
+        return str(self._current_water_level)
+
+    async def _try_command(self, mask_error: str, func, *args, **kwargs) -> bool:
         try:
             await self.hass.async_add_executor_job(partial(func, *args, **kwargs))
             return True
-        except DeviceException as exc:
+        except (DeviceException, OSError) as exc:
             _LOGGER.error(mask_error, exc)
             return False
 
+    async def async_locate(self, **kwargs) -> None:
+        await self._try_command("Unable to locate the vacuum: %s", self._vacuum.find)
 
-    async def async_locate(self, **kwargs):
-        """Locate the vacuum cleaner."""
-        await self._try_command("Unable to locate the botvac: %s", self._vacuum.find)
+    async def async_start(self) -> None:
+        await self._try_command("Unable to start the vacuum: %s", self._vacuum.start)
 
-    async def async_start(self):
-        """Start or resume the cleaning task."""
+    async def async_stop(self, **kwargs) -> None:
+        await self._try_command("Unable to stop the vacuum: %s", self._vacuum.stop)
+
+    async def async_clean_zone(self, zone: str, repeats: int = 1) -> None:
         await self._try_command(
-            "Unable to start the vacuum: %s", self._vacuum.start)
+            "Unable to send zoned_clean command to the vacuum: %s",
+            self._vacuum.zone_cleanup,
+            zone,
+        )
 
-    async def async_stop(self, **kwargs):
-        """Stop the vacuum cleaner."""
-        await self._try_command("Unable to stop: %s", self._vacuum.stop)
+    async def async_pause(self) -> None:
+        await self._try_command("Unable to pause the vacuum: %s", self._vacuum.stop)
 
-    async def async_clean_zone(self, zone, repeats=1):
-        """Clean selected area."""
-        try:
-            await self.hass.async_add_executor_job(self._vacuum.zone_cleanup, zone)
-        except (OSError, DeviceException) as exc:
-            _LOGGER.error("Unable to send zoned_clean command to the vacuum: %s", exc)
-
-    async def async_pause(self):
-        """Pause the cleaning task."""
-        await self._try_command("Unable to set start/pause: %s", self._vacuum.stop)
-
-    async def async_return_to_base(self, **kwargs):
-        """Set the vacuum cleaner to return to the dock."""
+    async def async_return_to_base(self, **kwargs) -> None:
         await self._try_command("Unable to return home: %s", self._vacuum.home)
 
-    async def async_set_fan_speed(self, fan_speed, **kwargs):
-        """Set fan speed."""
+    async def async_set_fan_speed(self, fan_speed: str, **kwargs) -> None:
+        if self._fan_speeds_reverse is None:
+            return
         if fan_speed in self._fan_speeds_reverse:
-            fan_speed = self._fan_speeds_reverse[fan_speed]
+            speed = self._fan_speeds_reverse[fan_speed]
         else:
             try:
-                fan_speed = int(fan_speed)
+                speed = int(fan_speed)
             except ValueError as exc:
                 _LOGGER.error(
                     "Fan speed step not recognized (%s). Valid speeds are: %s",
@@ -343,56 +246,59 @@ class MiroboVacuum(StateVacuumEntity):
                 )
                 return
         await self._try_command(
-            "Unable to set fan speed: %s", self._vacuum.set_fan_speed_preset, fan_speed)
+            "Unable to set fan speed: %s",
+            self._vacuum.set_fan_speed_preset,
+            speed,
+        )
 
-    async def async_set_water_level(self, water_level, **kwargs):
-        """Set water level."""
+    async def async_set_water_level(self, water_level: str, **kwargs) -> None:
+        if self._water_level_reverse is None:
+            return
         if water_level in self._water_level_reverse:
-            water_level = self._water_level_reverse[water_level]
+            level = self._water_level_reverse[water_level]
         else:
             try:
-                water_level = int(water_level)
+                level = int(water_level)
             except ValueError as exc:
                 _LOGGER.error(
-                    "water level step not recognized (%s). Valid are: %s",
+                    "Water level step not recognized (%s). Valid are: %s",
                     exc,
-                    self.water_level_list,
+                    list(self._water_level_reverse),
                 )
                 return
         await self._try_command(
-            "Unable to set water level: %s", self._vacuum.set_water_level, water_level)
+            "Unable to set water level: %s",
+            self._vacuum.set_water_level,
+            level,
+        )
 
+    async def async_update(self) -> None:
+        await self.hass.async_add_executor_job(self._update_state)
 
-
-    def update(self):
-        """Fetch state from the device."""
+    def _update_state(self) -> None:
         try:
             state = self._vacuum.status()
-            self.vacuum_state = str(state.state).split('.')[-1]
-            self.vacuum_error = state.error
+        except (DeviceException, OSError, TimeoutError) as exc:
+            _LOGGER.warning("Unable to fetch vacuum state: %s", exc)
+            return
 
-            self._fan_speeds = SPEED_CODE_TO_NAME
-            self._fan_speeds_reverse = {v: k for k, v in self._fan_speeds.items()}
+        self._fan_speeds_reverse = {
+            name: speed.value for speed, name in SPEED_CODE_TO_NAME.items()
+        }
+        self._water_level_reverse = {
+            name: level.value for level, name in WATER_CODE_TO_NAME.items()
+        }
 
-            self.battery_percentage = state.battery
-
-            self._current_fan_speed = str(state.fan_speed).split('.')[-1]
-
-            self._main_brush_time_left = str(state.main_brush_time_left)
-            self._main_brush_life_level = state.main_brush_life_level
-
-            self._side_brush_time_left = str(state.side_brush_time_left)
-            self._side_brush_life_level = state.side_brush_life_level
-
-            self._filter_life_level = state.filter_life_level
-            self._filter_left_time = str(state.filter_time_left)
-
-            self._cleaning_area = state.clean_area
-            self._cleaning_time = str(state.clean_time)
-			
-            self._water_level = WATER_CODE_TO_NAME
-            self._water_level_reverse = {v: k for k, v in self._water_level.items()}
-            self._current_water_level = state.water_level
-
-        except OSError as exc:
-            _LOGGER.error("Got OSError while fetching the state: %s", exc) 
+        self._attr_activity = G1_STATE_TO_ACTIVITY.get(state.state)
+        self._error = state.error
+        self._battery_percentage = state.battery
+        self._current_fan_speed = state.fan_speed.value
+        self._main_brush_time_left = _timedelta_minutes(state.main_brush_time_left)
+        self._main_brush_life_level = state.main_brush_life_level
+        self._side_brush_time_left = _timedelta_minutes(state.side_brush_time_left)
+        self._side_brush_life_level = state.side_brush_life_level
+        self._filter_life_level = state.filter_life_level
+        self._filter_left_time = _timedelta_minutes(state.filter_time_left)
+        self._cleaning_area = state.clean_area
+        self._cleaning_time = _timedelta_minutes(state.clean_time)
+        self._current_water_level = state.water_level.value

--- a/custom_components/xiaomi_vacuum/vacuum.py
+++ b/custom_components/xiaomi_vacuum/vacuum.py
@@ -79,9 +79,9 @@ SPEED_CODE_TO_NAME = {
 }
 
 WATER_CODE_TO_NAME = {
-    G1WaterLevel.Low: "Low",
-    G1WaterLevel.Medium: "Med",
-    G1WaterLevel.High: "High",
+    G1WaterLevel.Level1: "Low",
+    G1WaterLevel.Level2: "Med",
+    G1WaterLevel.Level3: "High",
 }
 
 

--- a/sensor_xiaomi_vacuum.yaml
+++ b/sensor_xiaomi_vacuum.yaml
@@ -1,59 +1,75 @@
-- platform: template
-  sensors:
-    vacuum_status:
-      friendly_name: "Vacuum - Status"
-      value_template: "Status: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.status }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_status
+      name: Vacuum - Status
+      state: >-
+        {% set vacuum = 'vacuum.mi_robot_vacuum_mop_essential' %}
+        Status: {{ state_attr(vacuum, 'status') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_name:
-      friendly_name: "Vacuum - Name"
-      value_template: "{{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.friendly_name }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_name
+      name: Vacuum - Name
+      state: "{{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'friendly_name') | default('Mi Robot Vacuum-Mop Essential') }}"
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_error:
-      friendly_name: "Vacuum - Error"
-      value_template: "{{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.error }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_error
+      name: Vacuum - Error
+      state: "{{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'error') | default('unknown') }}"
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_mode:
-      friendly_name: "Vacuum - Mode"
-      value_template: "Mode: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.fan_speed }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_mode
+      name: Vacuum - Mode
+      state: >-
+        Mode: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'fan_speed') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_area:
-      friendly_name: "Vacuum - Area"
-      value_template: "Area: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.cleaning_area }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_area
+      name: Vacuum - Area
+      state: >-
+        Area: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'cleaning_area') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_time:
-      friendly_name: "Vacuum - Time"
-      value_template: "Time: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.cleaning_time }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_time
+      name: Vacuum - Time
+      state: >-
+        Time: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'cleaning_time') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_main_brush:
-      friendly_name: "Vacuum - Main Brush"
-      value_template: "Main Brush: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.main_brush_time_left }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_main_brush
+      name: Vacuum - Main Brush
+      state: >-
+        Main Brush: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'main_brush_time_left') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_side_brush:
-      friendly_name: "Vacuum - Side Brush"
-      value_template: "Side Brush: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.side_brush_time_left }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_side_brush
+      name: Vacuum - Side Brush
+      state: >-
+        Side Brush: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'side_brush_time_left') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_filter:
-      friendly_name: "Vacuum - Filter"
-      value_template: "Filter: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.filter_left_time }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_filter
+      name: Vacuum - Filter
+      state: >-
+        Filter: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'filter_left_time') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
 
-- platform: template
-  sensors:
-    vacuum_battery:
-      friendly_name: "Vacuum - Battery"
-      value_template: "Battery: {{ states.vacuum.mi_robot_vacuum_mop_essential.attributes.battery_level }}"
+- sensor:
+    - default_entity_id: sensor.vacuum_sensor
+      name: Vacuum - Sensor
+      state: >-
+        Sensor: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'sensor_dirty_left') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"
+
+- sensor:
+    - default_entity_id: sensor.vacuum_battery
+      name: Vacuum - Battery
+      state: >-
+        Battery: {{ state_attr('vacuum.mi_robot_vacuum_mop_essential', 'battery_level') | default('unknown') }}
+      availability: "{{ has_value('vacuum.mi_robot_vacuum_mop_essential') }}"


### PR DESCRIPTION
## Summary
- Migrate vacuum platform to `VacuumEntityFeature` and `VacuumActivity` for Home Assistant 2026.3+
- Fix G1 (mijia.vacuum.v2) state/fan-speed mapping and use async updates with resilient error handling
- Expose `battery_level` and `sensor_dirty_left` via state attributes instead of deprecated vacuum battery APIs
- Update template sensors to the modern `template:` include format with availability guards
- Document the new include syntax in README

## Test plan
- [x] Deployed to homeassistant
- [x] `vacuum.mi_robot_vacuum_mop_essential` loads without import errors
- [x] Template sensors report status, battery, brushes, and filter data
- [x] No `sensor_dirty_left` / `battery_level` template warnings in logs